### PR TITLE
use options.cwd for default sourceRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ DESCRIPTION
 ---------------------------------------
 `espower-coffee` is a Node.js module loader that instruments [power-assert](http://github.com/power-assert-js/power-assert) feature into target CoffeeScript sources on the fly.
 
-Please note that `espower-coffee` is a beta version product. Pull-requests, issue reports and patches are always welcomed. See [power-assert](http://github.com/power-assert-js/power-assert) project for more documentation.
+Pull-requests, issue reports and patches are always welcomed. See [power-assert](http://github.com/power-assert-js/power-assert) project for more documentation.
 
 
 EXAMPLE

--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ require('espower-coffee')({
             'assert.strictEqual(actual, expected, [message])',
             'assert.notStrictEqual(actual, expected, [message])',
             'assert.deepEqual(actual, expected, [message])',
-            'assert.notDeepEqual(actual, expected, [message])'
+            'assert.notDeepEqual(actual, expected, [message])',
+            'assert.deepStrictEqual(actual, expected, [message])',
+            'assert.notDeepStrictEqual(actual, expected, [message])'
         ]
     }
 });

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function espowerCoffee (options) {
         withMap.js = espowerSource(
             withMap.js,
             filepath,
-            extend(options.espowerOptions, {sourceMap: conv.toObject()})
+            extend(options.espowerOptions, { sourceMap: conv.toObject(), sourceRoot: options.cwd })
         );
         return sourceMap ? withMap : withMap.js;
     };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/power-assert-js/espower-coffee/issues",
   "dependencies": {
     "convert-source-map": "^1.1.0",
-    "espower-source": "git://github.com/power-assert-js/espower-source.git",
+    "espower-source": "^1.0.0",
     "minimatch": "^2.0.1",
     "xtend": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/power-assert-js/espower-coffee/issues",
   "dependencies": {
     "convert-source-map": "^1.1.0",
-    "espower-source": "^0.10.0",
+    "espower-source": "git://github.com/power-assert-js/espower-source.git#source-root",
     "minimatch": "^2.0.1",
     "xtend": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/power-assert-js/espower-coffee/issues",
   "dependencies": {
     "convert-source-map": "^1.1.0",
-    "espower-source": "git://github.com/power-assert-js/espower-source.git#source-root",
+    "espower-source": "git://github.com/power-assert-js/espower-source.git",
     "minimatch": "^2.0.1",
     "xtend": "^4.0.0"
   },

--- a/test/tobe_instrumented/tobe_instrumented_test.coffee
+++ b/test/tobe_instrumented/tobe_instrumented_test.coffee
@@ -5,14 +5,6 @@ expect = require("expect.js")
 
 describe "power-assert message", ->
 
-  beforeEach ->
-    @expectPowerAssertMessage = (body, expectedLines) ->
-      try
-        body()
-        expect().fail "AssertionError should be thrown"
-      catch e
-        expect(e.message.split("\n").slice(2, -1)).to.eql expectedLines
-
   it "Nested CallExpression with BinaryExpression: assert((three * (seven * ten)) === three);", ->
     one = 1
     two = 2
@@ -33,7 +25,7 @@ describe "power-assert message", ->
       "  => 3"
       "  [number] three * (seven * ten)"
       "  => 210"
-    ]
+    ], "  # test/tobe_instrumented/tobe_instrumented_test.coffee:15"
 
   it "equal with Literal and Identifier: assert.equal(1, minusOne);", ->
     minusOne = -1
@@ -43,4 +35,13 @@ describe "power-assert message", ->
       "  assert.equal(1, minusOne)"
       "                  |        "
       "                  -1       "
-    ]
+    ], "  # test/tobe_instrumented/tobe_instrumented_test.coffee:33"
+
+  beforeEach ->
+    @expectPowerAssertMessage = (body, expectedDiagram, expectedLine) ->
+      try
+        body()
+        expect().fail "AssertionError should be thrown"
+      catch e
+        expect(e.message.split("\n")[0]).to.eql expectedLine
+        expect(e.message.split("\n").slice(2, -1)).to.eql expectedDiagram


### PR DESCRIPTION
Dealing with `sourceRoot` option to display relative paths.

Related topics:

- [sourceRoot option by twada · Pull Request #7 · power-assert-js/espower-source](https://github.com/power-assert-js/espower-source/pull/7)
- [sourceRoot option by twada · Pull Request #18 · power-assert-js/espower](https://github.com/power-assert-js/espower/pull/18)
- [convert relative filepath for security reason · Issue #20 · power-assert-js/power-assert](https://github.com/power-assert-js/power-assert/issues/20)