### PR TITLE
upgrade espower-source to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,17 +10,16 @@
   "bugs": "https://github.com/power-assert-js/espower-coffee/issues",
   "dependencies": {
     "convert-source-map": "^1.1.0",
-    "espower-source": "^1.0.0",
+    "espower-source": "^2.0.0",
     "minimatch": "^3.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
     "coffee-script": "^1.7.1",
-    "empower": "^1.0.0",
     "expect.js": "^0.3.1",
     "jshint": "^2.8.0",
     "mocha": "^3.0.0",
-    "power-assert-formatter": "^1.0.0"
+    "power-assert": "^1.4.2"
   },
   "directories": {
     "test": "test/tobe_instrumented"

--- a/test/not_tobe_instrumented/not_instrumented_test.coffee
+++ b/test/not_tobe_instrumented/not_instrumented_test.coffee
@@ -1,6 +1,4 @@
-empower = require("empower")
-formatter = require("power-assert-formatter")()
-assert = empower(require("assert"), formatter)
+assert = require("assert")
 expect = require("expect.js")
 
 describe "power-assert client should work with not-instrumented code", ->

--- a/test/tobe_instrumented/tobe_instrumented_test.coffee
+++ b/test/tobe_instrumented/tobe_instrumented_test.coffee
@@ -1,6 +1,4 @@
-empower = require("empower")
-formatter = require("power-assert-formatter")()
-assert = empower(require("assert"), formatter)
+assert = require("assert")
 expect = require("expect.js")
 
 describe "power-assert message", ->
@@ -25,7 +23,7 @@ describe "power-assert message", ->
       "  => 3"
       "  [number] three * (seven * ten)"
       "  => 210"
-    ], "  # test/tobe_instrumented/tobe_instrumented_test.coffee:15"
+    ], "  # test/tobe_instrumented/tobe_instrumented_test.coffee:13"
 
   it "equal with Literal and Identifier: assert.equal(1, minusOne);", ->
     minusOne = -1
@@ -35,7 +33,7 @@ describe "power-assert message", ->
       "  assert.equal(1, minusOne)"
       "                  |        "
       "                  -1       "
-    ], "  # test/tobe_instrumented/tobe_instrumented_test.coffee:33"
+    ], "  # test/tobe_instrumented/tobe_instrumented_test.coffee:31"
 
   beforeEach ->
     @expectPowerAssertMessage = (body, expectedDiagram, expectedLine) ->


### PR DESCRIPTION
Now `require('assert')` in tests are empowered transparently

see:

- [Integrate `empower-assert` to enable transparent assertion enhancement](https://github.com/power-assert-js/espower-source/pull/11)
- [Embed value capturing helper into transpiled code](https://github.com/power-assert-js/espower/pull/26)
